### PR TITLE
chore: fix character misencodings

### DIFF
--- a/class/dashboard/subpage-main.php
+++ b/class/dashboard/subpage-main.php
@@ -121,7 +121,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 	 *
 	 * @since 2.0.4 to reflect changes in meta box label display since WPv5.5
 	 * spans need position:fixed and become unlocalizable
-	 * fix: logo is kept only in the label that doesnâ€™t need to be translated:
+	 * fix: logo is kept only in the label that doesn't need to be translated:
 	 * Change string "%s styling" to "Footnotes styling" to fix layout in WPv5.5
 	 * @see details in class/config.php
 	 *
@@ -179,13 +179,13 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 		// Replace all placeholders.
 		$l_obj_template->replace(
 			array(
-				// Translators: '%s' is the link text 'AMP-WP' linked to the pluginâ€™s front page on WordPress.org.
+				// Translators: '%s' is the link text 'AMP-WP' linked to the plugin's front page on WordPress.org.
 				'description-1-amp' => sprintf( __( 'The official %s plugin is required when this option is enabled.', 'footnotes' ), '<a href="https://wordpress.org/plugins/amp/" target="_blank" style="font-style: normal;">AMP-WP</a>' ),
 				'label-amp'         => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_AMP_COMPATIBILITY_ENABLE, __( 'Enable AMP compatibility mode:', 'footnotes' ) ),
 				'amp'               => $this->add_checkbox( MCI_Footnotes_Settings::C_STR_FOOTNOTES_AMP_COMPATIBILITY_ENABLE ),
 				'notice-amp'        => __( 'This option enables hard links with configurable scroll offset in % viewport height.', 'footnotes' ),
 				// Translators: '%s' is the logogram of the 'Footnotes' plugin.
-				'description-2-amp' => sprintf( __( '%s is becoming AMP compatible when this box is checked. Styled tooltips are displayed with fade-in/fade-out effect if enabled, and the reference container expands also on clicking a referrer if itâ€™s collapsed by default.', 'footnotes' ), '<span style="font-style: normal;">' . MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME . '</span>' ),
+				'description-2-amp' => sprintf( __( '%s is becoming AMP compatible when this box is checked. Styled tooltips are displayed with fade-in/fade-out effect if enabled, and the reference container expands also on clicking a referrer if it\'s collapsed by default.', 'footnotes' ), '<span style="font-style: normal;">' . MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME . '</span>' ),
 			)
 		);
 		// Display template with replaced placeholders.
@@ -237,7 +237,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 			);
 			// Options for the terminating punctuation after backlinks.
 			// The Unicode name of RIGHT PARENTHESIS was originally more accurate because.
-			// This character is bidi-mirrored. Letâ€™s use the Unicode 1.0 name.
+			// This character is bidi-mirrored. Let's use the Unicode 1.0 name.
 			// The wrong names were enforced in spite of Unicode, that subsequently scrambled to correct.
 			$l_arr_terminators = array(
 				'period'      => __( 'FULL STOP', 'footnotes' ),
@@ -272,7 +272,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 					'label-name'           => $this->add_label( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_NAME, __( 'Heading:', 'footnotes' ) ),
 					'name'                 => $this->add_text_box( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_NAME ),
 
-					'label-element'        => $this->add_label( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_LABEL_ELEMENT, __( 'Headingâ€™s HTML element:', 'footnotes' ) ),
+					'label-element'        => $this->add_label( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_LABEL_ELEMENT, __( 'Heading\'s HTML element:', 'footnotes' ) ),
 					'element'              => $this->add_select_box( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_LABEL_ELEMENT, $l_arr_label_element ),
 
 					'label-border'         => $this->add_label( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_LABEL_BOTTOM_BORDER, __( 'Border under the heading:', 'footnotes' ) ),
@@ -307,11 +307,11 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 
 					'label-page-layout'    => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_PAGE_LAYOUT_SUPPORT, __( 'Apply basic responsive page layout:', 'footnotes' ) ),
 					'page-layout'          => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_PAGE_LAYOUT_SUPPORT, $l_arr_page_layout_options ),
-					'notice-page-layout'   => __( 'Most themes donâ€™t need this fix.', 'footnotes' ),
+					'notice-page-layout'   => __( 'Most themes don\'t need this fix.', 'footnotes' ),
 
 					'label-url-wrap'       => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTE_URL_WRAP_ENABLED, __( 'Allow URLs to line-wrap anywhere:', 'footnotes' ) ),
 					'url-wrap'             => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTE_URL_WRAP_ENABLED, $l_arr_enabled ),
-					'notice-url-wrap'      => __( 'Unicode-conformant browsers donâ€™t need this fix.', 'footnotes' ),
+					'notice-url-wrap'      => __( 'Unicode-conformant browsers don\'t need this fix.', 'footnotes' ),
 
 					'label-symbol'         => $this->add_label( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_BACKLINK_SYMBOL_ENABLE, __( 'Display a backlink symbol:', 'footnotes' ) ),
 					'symbol-enable'        => $this->add_select_box( MCI_Footnotes_Settings::C_STR_REFERENCE_CONTAINER_BACKLINK_SYMBOL_ENABLE, $l_arr_enabled ),
@@ -343,13 +343,13 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 					'width-enable'         => $this->add_select_box( MCI_Footnotes_Settings::C_STR_BACKLINKS_COLUMN_WIDTH_ENABLED, $l_arr_enabled ),
 					'width-scalar'         => $this->add_num_box( MCI_Footnotes_Settings::C_INT_BACKLINKS_COLUMN_WIDTH_SCALAR, 0, 500, true ),
 					'width-unit'           => $this->add_select_box( MCI_Footnotes_Settings::C_STR_BACKLINKS_COLUMN_WIDTH_UNIT, $l_arr_width_units ),
-					'notice-width'         => __( 'Absolute width in pixels doesnâ€™t need to be accurate to the tenth, but relative width in rem or em may.', 'footnotes' ),
+					'notice-width'         => __( 'Absolute width in pixels doesn\'t need to be accurate to the tenth, but relative width in rem or em may.', 'footnotes' ),
 
 					'label-max-width'      => $this->add_label( MCI_Footnotes_Settings::C_STR_BACKLINKS_COLUMN_MAX_WIDTH_ENABLED, __( 'Set backlinks column maximum width:', 'footnotes' ) ),
 					'max-width-enable'     => $this->add_select_box( MCI_Footnotes_Settings::C_STR_BACKLINKS_COLUMN_MAX_WIDTH_ENABLED, $l_arr_enabled ),
 					'max-width-scalar'     => $this->add_num_box( MCI_Footnotes_Settings::C_INT_BACKLINKS_COLUMN_MAX_WIDTH_SCALAR, 0, 500, true ),
 					'max-width-unit'       => $this->add_select_box( MCI_Footnotes_Settings::C_STR_BACKLINKS_COLUMN_MAX_WIDTH_UNIT, $l_arr_width_units ),
-					'notice-max-width'     => __( 'Absolute width in pixels doesnâ€™t need to be accurate to the tenth, but relative width in rem or em may.', 'footnotes' ),
+					'notice-max-width'     => __( 'Absolute width in pixels doesn\'t need to be accurate to the tenth, but relative width in rem or em may.', 'footnotes' ),
 
 					'label-line-break'     => $this->add_label( MCI_Footnotes_Settings::C_STR_BACKLINKS_LINE_BREAKS_ENABLED, __( 'Stack backlinks when enumerating:', 'footnotes' ) ),
 					'line-break'           => $this->add_select_box( MCI_Footnotes_Settings::C_STR_BACKLINKS_LINE_BREAKS_ENABLED, $l_arr_enabled ),
@@ -357,7 +357,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 
 					'label-link'           => $this->add_label( MCI_Footnotes_Settings::C_STR_LINK_ELEMENT_ENABLED, __( 'Use the link element for referrers and backlinks:', 'footnotes' ) ),
 					'link'                 => $this->add_select_box( MCI_Footnotes_Settings::C_STR_LINK_ELEMENT_ENABLED, $l_arr_enabled ),
-					'notice-link'          => __( 'The link element is needed to apply the themeâ€™s link color.', 'footnotes' ),
+					'notice-link'          => __( 'The link element is needed to apply the theme\'s link color.', 'footnotes' ),
 					'description-link'     => __( 'If the link element is not desired for styling, a simple span is used instead when the above is set to No. The link addresses have been removed. Else footnote clicks are logged in the browsing history and make the back button unusable.', 'footnotes' ),
 				)
 			);
@@ -447,7 +447,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				'syntax'                   => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTE_SHORTCODE_SYNTAX_VALIDATION_ENABLE, $l_arr_enable ),
 				'notice-syntax'            => __( 'In the presence of a lone start tag shortcode, a warning displays below the post title.', 'footnotes' ),
 
-				'description-syntax'       => __( 'If the start tag short code is â€˜((â€™ or â€˜(((â€™, it will not be reported as unbalanced if the following string contains braces hinting that it is a script.', 'footnotes' ),
+				'description-syntax'       => __( 'If the start tag short code is \'((\' or \'(((\', it will not be reported as unbalanced if the following string contains braces hinting that it is a script.', 'footnotes' ),
 			)
 		);
 		// Display template with replaced placeholders.
@@ -471,12 +471,12 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 		);
 		// Options for the numbering style of the footnotes.
 		$l_arr_counter_style = array(
-			'arabic_plain'   => __( 'plain Arabic numbers', 'footnotes' ) . $l_str_space . '1, 2, 3, 4, 5, â€¦',
-			'arabic_leading' => __( 'zero-padded Arabic numbers', 'footnotes' ) . $l_str_space . '01, 02, 03, 04, 05, â€¦',
-			'latin_low'      => __( 'lowercase Latin letters', 'footnotes' ) . $l_str_space . 'a, b, c, d, e, â€¦',
-			'latin_high'     => __( 'uppercase Latin letters', 'footnotes' ) . $l_str_space . 'A, B, C, D, E, â€¦',
-			'romanic'        => __( 'uppercase Roman numerals', 'footnotes' ) . $l_str_space . 'I, II, III, IV, V, â€¦',
-			'roman_low'      => __( 'lowercase Roman numerals', 'footnotes' ) . $l_str_space . 'i, ii, iii, iv, v, â€¦',
+			'arabic_plain'   => __( 'plain Arabic numbers', 'footnotes' ) . $l_str_space . '1, 2, 3, 4, 5, ...',
+			'arabic_leading' => __( 'zero-padded Arabic numbers', 'footnotes' ) . $l_str_space . '01, 02, 03, 04, 05, ...',
+			'latin_low'      => __( 'lowercase Latin letters', 'footnotes' ) . $l_str_space . 'a, b, c, d, e, ...',
+			'latin_high'     => __( 'uppercase Latin letters', 'footnotes' ) . $l_str_space . 'A, B, C, D, E, ...',
+			'romanic'        => __( 'uppercase Roman numerals', 'footnotes' ) . $l_str_space . 'I, II, III, IV, V, ...',
+			'roman_low'      => __( 'lowercase Roman numerals', 'footnotes' ) . $l_str_space . 'i, ii, iii, iv, v, ...',
 		);
 
 		// Load template file.
@@ -638,7 +638,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 			'text-2' => sprintf( __( 'This website uses the awesome %s plugin.', 'footnotes' ), MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME ),
 			'random' => __( 'randomly determined display of either mention', 'footnotes' ),
 			// Translators: 1: Plugin logo.2: heart symbol.
-			'no'     => sprintf( __( 'no display of any â€œ%1$s %2$sâ€ mention in the footer', 'footnotes' ), MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME, MCI_Footnotes_Config::C_STR_LOVE_SYMBOL ),
+			'no'     => sprintf( __( 'no display of any "%1$s %2$s" mention in the footer', 'footnotes' ), MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME, MCI_Footnotes_Config::C_STR_LOVE_SYMBOL ),
 		);
 
 		// Load template file.
@@ -647,7 +647,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 		$l_obj_template->replace(
 			array(
 				// Translators: %s: Footnotes plugin logo.
-				'label-love'    => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_LOVE, sprintf( __( 'Tell the world youâ€™re using %s:', 'footnotes' ), MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME ) ),
+				'label-love'    => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_LOVE, sprintf( __( 'Tell the world you\'re using %s:', 'footnotes' ), MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME ) ),
 				'love'          => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_LOVE, $l_arr_love ),
 
 				// Translators: %s: Footnotes plugin logo.
@@ -687,9 +687,9 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				'label-excerpts'       => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_IN_EXCERPT, __( 'Display footnotes in excerpts:', 'footnotes' ) ),
 				'excerpts'             => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_IN_EXCERPT, $l_arr_enabled ),
 				'notice-excerpts'      => __( 'For this setting to be effective, the hook the_excerpt must be enabled under Scope and priority.', 'footnotes' ),
-				// Translators: %s: link text 'Advanced Excerpt' linked to the pluginâ€™s WordPress.org front page.
+				// Translators: %s: link text 'Advanced Excerpt' linked to the plugin's WordPress.org front page.
 				// Translators: %s: Footnotes plugin logo.
-				'description-excerpts' => sprintf( __( 'Both to display footnotes and to not display footnotes in excerpts, the %s plugin generates excerpts on the basis of the posts to ensure that footnotes are handled and donâ€™t impact the excerpt length.', 'footnotes' ), '<span style="font-style: normal;">' . MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME . '</span>' ),
+				'description-excerpts' => sprintf( __( 'Both to display footnotes and to not display footnotes in excerpts, the %s plugin generates excerpts on the basis of the posts to ensure that footnotes are handled and don\'t impact the excerpt length.', 'footnotes' ), '<span style="font-style: normal;">' . MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME . '</span>' ),
 			)
 		);
 		// Display template with replaced placeholders.
@@ -729,7 +729,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 
 				'label-normalize'   => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTE_REFERRERS_NORMAL_SUPERSCRIPT, __( 'Normalize vertical alignment and font size:', 'footnotes' ) ),
 				'normalize'         => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTE_REFERRERS_NORMAL_SUPERSCRIPT, $l_arr_normalize_superscript ),
-				'notice-normalize'  => __( 'Most themes donâ€™t need this fix.', 'footnotes' ),
+				'notice-normalize'  => __( 'Most themes don\'t need this fix.', 'footnotes' ),
 
 				'label-before'      => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_STYLING_BEFORE, __( 'At the start of the footnote referrers:', 'footnotes' ) ),
 				'before'            => $this->add_text_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_STYLING_BEFORE ),
@@ -738,7 +738,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				'after'             => $this->add_text_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_STYLING_AFTER ),
 
 				'label-link'        => $this->add_label( MCI_Footnotes_Settings::C_STR_LINK_ELEMENT_ENABLED, __( 'Use the link element for referrers and backlinks:', 'footnotes' ) ),
-				'notice-link'       => __( 'Please find this setting at the end of the reference container settings. The link element is needed to apply the themeâ€™s link color.', 'footnotes' ),
+				'notice-link'       => __( 'Please find this setting at the end of the reference container settings. The link element is needed to apply the theme\'s link color.', 'footnotes' ),
 			)
 		);
 		// Display template with replaced placeholders.
@@ -756,7 +756,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 		// Options for the input label issue solution.
 		$l_arr_issue_solutions = array(
 			'none'       => __( '0. No problem or solved otherwise', 'footnotes' ),
-			'move'       => __( 'A. Footnotes are moved out and appended after the labelâ€™s end (recommended)', 'footnotes' ),
+			'move'       => __( 'A. Footnotes are moved out and appended after the label\'s end (recommended)', 'footnotes' ),
 			'disconnect' => __( 'B. Labels with footnotes are disconnected from input element (discouraged)', 'footnotes' ),
 		);
 		// Load template file.
@@ -764,10 +764,10 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 		// Replace all placeholders.
 		$l_obj_template->replace(
 			array(
-				'description-1-selection' => __( 'Clicking a footnote referrer in an input element label toggles the input except when hard links are enabled. In jQuery mode, the recommended solution is to move footnotes and append them after the label (optionâ€¯A).', 'footnotes' ),
+				'description-1-selection' => __( 'Clicking a footnote referrer in an input element label toggles the input except when hard links are enabled. In jQuery mode, the recommended solution is to move footnotes and append them after the label (option A).', 'footnotes' ),
 				'label-selection'         => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_LABEL_ISSUE_SOLUTION, __( 'Solve input label issue:', 'footnotes' ) ),
 				'selection'               => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_LABEL_ISSUE_SOLUTION, $l_arr_issue_solutions ),
-				'description-2-selection' => __( 'Option B is discouraged because disconnecting a label from its input element may compromise accessibility. This option is a last resort in case footnotes must absolutely stay inside the label. (Using jQuery â€˜event.stopPropagationâ€™ failed.)', 'footnotes' ),
+				'description-2-selection' => __( 'Option B is discouraged because disconnecting a label from its input element may compromise accessibility. This option is a last resort in case footnotes must absolutely stay inside the label. (Using jQuery \'event.stopPropagation\' failed.)', 'footnotes' ),
 			)
 		);
 		// Display template with replaced placeholders.
@@ -806,7 +806,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				'alternative'             => $this->add_select_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_ALTERNATIVE, $l_arr_enabled ),
 				'notice-alternative'      => __( 'Intended to work around a configuration-related tooltip outage.', 'footnotes' ),
 				// Translators: %s: Footnotes plugin logo.
-				'description-alternative' => sprintf( __( 'These alternative tooltips work around a website related jQuery UI outage. They are low-script but use the AMP incompatible onmouseover and onmouseout arguments, along with CSS transitions for fade-in/out. The very small script is inserted after Footnotesâ€™ internal stylesheet. When this option is enabled, %s does not load jQuery&nbsp;UI nor jQuery&nbsp;Tools.', 'footnotes' ), '<span style="font-style: normal;">' . MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME . '</span>' ),
+				'description-alternative' => sprintf( __( 'These alternative tooltips work around a website related jQuery UI outage. They are low-script but use the AMP incompatible onmouseover and onmouseout arguments, along with CSS transitions for fade-in/out. The very small script is inserted after Footnotes\' internal stylesheet. When this option is enabled, %s does not load jQuery&nbsp;UI nor jQuery&nbsp;Tools.', 'footnotes' ), '<span style="font-style: normal;">' . MCI_Footnotes_Config::C_STR_PLUGIN_PUBLIC_NAME . '</span>' ),
 
 			)
 		);
@@ -960,7 +960,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				// The feature trims back until the last full word.
 				'notice-max-length' => __( 'No weird cuts.', 'footnotes' ),
 
-				'label-readon'      => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_TOOLTIP_READON_LABEL, __( 'â€˜Read onâ€™ button label:', 'footnotes' ) ),
+				'label-readon'      => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_TOOLTIP_READON_LABEL, __( '\'Read on\' button label:', 'footnotes' ) ),
 				'readon'            => $this->add_text_box( MCI_Footnotes_Settings::C_STR_FOOTNOTES_TOOLTIP_READON_LABEL ),
 
 			)
@@ -1050,12 +1050,12 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				'label-color'             => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_COLOR, __( 'Text color:', 'footnotes' ) ),
 				'color'                   => $this->add_color_selection( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_COLOR ),
 				// Translators: %s: Clear or leave empty.
-				'notice-color'            => sprintf( __( 'To use the current themeâ€™s default text color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
+				'notice-color'            => sprintf( __( 'To use the current theme\'s default text color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
 
 				'label-background'        => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_BACKGROUND, __( 'Background color:', 'footnotes' ) ),
 				'background'              => $this->add_color_selection( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_BACKGROUND ),
 				// Translators: %s: Clear or leave empty.
-				'notice-background'       => sprintf( __( 'To use the current themeâ€™s default background color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
+				'notice-background'       => sprintf( __( 'To use the current theme\'s default background color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
 
 				'label-border-width'      => $this->add_label( MCI_Footnotes_Settings::C_INT_FOOTNOTES_MOUSE_OVER_BOX_BORDER_WIDTH, __( 'Border width:', 'footnotes' ) ),
 				'border-width'            => $this->add_num_box( MCI_Footnotes_Settings::C_INT_FOOTNOTES_MOUSE_OVER_BOX_BORDER_WIDTH, 0, 4, true ),
@@ -1064,7 +1064,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				'label-border-color'      => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_BORDER_COLOR, __( 'Border color:', 'footnotes' ) ),
 				'border-color'            => $this->add_color_selection( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_BORDER_COLOR ),
 				// Translators: %s: Clear or leave empty.
-				'notice-border-color'     => sprintf( __( 'To use the current themeâ€™s default border color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
+				'notice-border-color'     => sprintf( __( 'To use the current theme\'s default border color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
 
 				'label-border-radius'     => $this->add_label( MCI_Footnotes_Settings::C_INT_FOOTNOTES_MOUSE_OVER_BOX_BORDER_RADIUS, __( 'Rounded corner radius:', 'footnotes' ) ),
 				'border-radius'           => $this->add_num_box( MCI_Footnotes_Settings::C_INT_FOOTNOTES_MOUSE_OVER_BOX_BORDER_RADIUS, 0, 500 ),
@@ -1073,7 +1073,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 				'label-box-shadow-color'  => $this->add_label( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_SHADOW_COLOR, __( 'Box shadow color:', 'footnotes' ) ),
 				'box-shadow-color'        => $this->add_color_selection( MCI_Footnotes_Settings::C_STR_FOOTNOTES_MOUSE_OVER_BOX_SHADOW_COLOR ),
 				// Translators: %s: Clear or leave empty.
-				'notice-box-shadow-color' => sprintf( __( 'To use the current themeâ€™s default box shadow color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
+				'notice-box-shadow-color' => sprintf( __( 'To use the current theme\'s default box shadow color: %s', 'footnotes' ), __( 'Clear or leave empty.', 'footnotes' ) ),
 
 			)
 		);
@@ -1154,7 +1154,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 
 				// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 				// CSS classes are listed in the template.
-				// Localized notices are dropped to ease translatorsâ€™ task.
+				// Localized notices are dropped to ease translators' task.
 
 				// "label-class-1" => ".footnote_plugin_tooltip_text",.
 				// "class-1" => $this->add_text(__("superscript, Footnotes index", MCI_Footnotes_Config::C_STR_PLUGIN_NAME)),.
@@ -1342,7 +1342,7 @@ class MCI_Footnotes_Layout_Settings extends MCI_Footnotes_Layout_Engine {
 			array(
 				'label-start'    => __( 'Start your footnote with the following short code:', 'footnotes' ),
 				'start'          => $l_arr_footnote_starting_tag['value'],
-				'label-end'      => __( 'â€¦and end your footnote with this short code:', 'footnotes' ),
+				'label-end'      => __( '...and end your footnote with this short code:', 'footnotes' ),
 				'end'            => $l_arr_footnote_ending_tag['value'],
 				'example-code'   => $l_str_example,
 				'example-string' => '<br/>' . __( 'will be displayed as:', 'footnotes' ),

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Visit this swift write-up from a **footnotes** user by the name of **Southwest**
 
 = 2.6.6 =
 - Bugfix: Process: fix issue that caused some footnotes to not be processed, thanks to @docteurfitness bug report.
+- Bugfix: Display: fix characters that had been mis-encoded.
 
 = 2.6.5 =
 - Bugfix: Editor buttons: debug button by reverting name change in PHP file while JS file and HTML template remained unsynced, thanks to @gova bug report.


### PR DESCRIPTION
Various characters had been replaced by ‘â€’s.

Fix #77