### PR TITLE
update snyk scan frequency

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,6 +1,6 @@
 name: Snyk 
 
-on: push
+on: pull_request
 
 jobs:
   security:


### PR DESCRIPTION
I switched Snyk over to their "Open Source Scanning" model. This means our repo will be scanned daily and with every push and PR. In order to tune down the frequency of the report generation for GH and to save on the number of tasks and the execution time, I'm updating the Snyk action to only run on PRs instead of pushes.