### PR TITLE
Add SVN release workflow

### DIFF
--- a/.github/workflows/release-handler.yml
+++ b/.github/workflows/release-handler.yml
@@ -1,13 +1,17 @@
-name: Pre-release Handler
+# This workflow handles GitHub releases and pre-releases.
+# It builds the Plugin, adds an archive artifact to the
+# release entry on GitHub and (in the case of a full release)
+# pushes the release to the WP Plugin Directory SVN repo.
+
+name: Release Handler
 
 on:
   release:
     types: [published]
 
 jobs:
-  build:
+  build_plugin:
     name: Build the Plugin for pre-release
-    if: "github.event.release.prerelease"
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +30,12 @@ jobs:
         run: |
           mv dist/ footnotes/
 
+  create_archive:
+    name: Create an archive for the release and add it to GitHub
+    runs-on: ubuntu-latest
+    needs: build_plugin
+
+    steps:
       - name: Create release archive
         uses: montudor/action-zip@v0.1.0
         with:
@@ -44,10 +54,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      #- name: Deploy release to Wordpress.org 
-      #  uses: 10up/action-wordpress-plugin-deploy@stable
-      #  with:
-      #    generate-zip: true
-      #  env:
-      #    SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-      #    SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+  release_to_svn:
+    name: Push the release to the WordPress Plugin Directory repo.
+    if: "!github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    needs: create_archive
+
+    steps:
+      - name: Deploy release to Wordpress.org 
+        id: deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: footnotes/branches/svn-test
+          ASSETS_DIR: assets

--- a/.github/workflows/release-handler.yml
+++ b/.github/workflows/release-handler.yml
@@ -1,5 +1,5 @@
 # This workflow handles GitHub releases and pre-releases.
-# It builds the Plugin, adds an archive artifact to the
+# It builds the Plugin, zips up an archive to add to the
 # release entry on GitHub and (in the case of a full release)
 # pushes the release to the WP Plugin Directory SVN repo.
 

--- a/.github/workflows/release-handler.yml
+++ b/.github/workflows/release-handler.yml
@@ -25,10 +25,16 @@ jobs:
       - name: Build Plugin
         run: |
           composer run build
-          
-      - name: Rename dist/ folder
+
+      - name: Rename Plugin folder
         run: |
           mv dist/ footnotes/
+          
+      - name: Upload Plugin artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: footnotes-${{ github.event.release.tag_name }}
+          path: footnotes
 
   create_archive:
     name: Create an archive for the release and add it to GitHub
@@ -36,17 +42,22 @@ jobs:
     needs: build_plugin
 
     steps:
+      - name: Download Plugin artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: footnotes-${{ github.event.release.tag_name }}
+
       - name: Create release archive
         uses: montudor/action-zip@v0.1.0
         with:
           args: zip -X -r footnotes-${{ github.event.release.tag_name }}.zip footnotes
-
+"""
       - name: Upload archive as artifact
         uses: actions/upload-artifact@v2
         with:
             name: footnotes-${{ github.event.release.tag_name }}
             path: footnotes-${{ github.event.release.tag_name }}.zip
-            
+"""         
       - name: Upload archive to release
         uses: JasonEtco/upload-to-release@master
         with:
@@ -61,6 +72,11 @@ jobs:
     needs: create_archive
 
     steps:
+      - name: Download Plugin artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: footnotes-${{ github.event.release.tag_name }}
+
       - name: Deploy release to Wordpress.org 
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@stable

--- a/.github/workflows/release-handler.yml
+++ b/.github/workflows/release-handler.yml
@@ -51,13 +51,13 @@ jobs:
         uses: montudor/action-zip@v0.1.0
         with:
           args: zip -X -r footnotes-${{ github.event.release.tag_name }}.zip footnotes
-"""
-      - name: Upload archive as artifact
-        uses: actions/upload-artifact@v2
-        with:
-            name: footnotes-${{ github.event.release.tag_name }}
-            path: footnotes-${{ github.event.release.tag_name }}.zip
-"""         
+
+      #- name: Upload archive as artifact
+      #  uses: actions/upload-artifact@v2
+      #  with:
+      #      name: footnotes-${{ github.event.release.tag_name }}
+      #      path: footnotes-${{ github.event.release.tag_name }}.zip
+         
       - name: Upload archive to release
         uses: JasonEtco/upload-to-release@master
         with:

--- a/_tools/release.sh
+++ b/_tools/release.sh
@@ -65,7 +65,7 @@ echo "- Checking versions..."
 
 STABLE_TAG="$(grep "Stable Tag:" src/readme.txt)"
 ROOT_HEADER_VERSION="$(grep " Version:" src/footnotes.php | grep -Po " Version: \d+\.\d+(\.\d+)?[a-z]?$")"
-JS_VERSION="$(grep "version :" src/js/wysiwyg-editor.js)"
+JS_VERSION="$(grep "version:" src/js/wysiwyg-editor.js)"
 
 # Step 3(b): Check that all version declarations exists
 

--- a/src/footnotes.php
+++ b/src/footnotes.php
@@ -113,7 +113,20 @@ require_once dirname( __FILE__ ) . '/includes.php';
 $l_str_plugin_file = 'footnotes/footnotes.php';
 add_filter( "plugin_action_links_{$l_str_plugin_file}", array( 'Footnotes_Hooks', 'get_plugin_links' ), 10, 2 );
 
-// Initialize the Plugin.
-$g_obj_mci_footnotes = new Footnotes();
-// Run the Plugin.
-$g_obj_mci_footnotes->run();
+/**
+ * Initialises and runs the Plugin.
+ *
+ * This takes place after the `plugins_loaded` hook, so that
+ * other Plugins may filter options.
+ *
+ * @since 2.7.4
+ */
+add_action(
+	'plugins_loaded',
+	function() {
+		// Initialize the Plugin.
+		$g_obj_mci_footnotes = new Footnotes();
+		// Run the Plugin.
+		$g_obj_mci_footnotes->run();
+	}
+);

--- a/src/wpml-config.xml
+++ b/src/wpml-config.xml
@@ -2,6 +2,7 @@
 	<admin-texts>
 		<key name="footnotes_storage">
 		    <key name="footnote_inputfield_references_label" />
+		    <key name="footnote_inputfield_readon_label" />
 		</key>
 	</admin-texts>
 </wpml-config>


### PR DESCRIPTION
This should allow us to create releases here and have them be automatically pushed to the SVN repo.

The workflow will only do this for full releases; pre-releases *should* remain GitHub-only.

Obviously this will need some testing. I've set it up to push to `footnotes/branches/svn-test/` (`.github/workflows/release-handler.yml:70`), so @markcheret could you please create this folder (I'm on a new computer and don't have any SVN stuff set up).

Then we should be able to test the workflow on both a pre-release and a regular release without interfering with the plugin users and see how it goes. I have a sneaking suspicion that it may end up putting everything inside `footnotes/branches/svn-test/footnotes-${{ github.event.release.tag_name }}/`, but that shouldn't be too tricky to remedy if so.

Close #89 #90 #189 #190